### PR TITLE
Fix error when $results doesn't have keys

### DIFF
--- a/Providers/WordPressFreeScoutServiceProvider.php
+++ b/Providers/WordPressFreeScoutServiceProvider.php
@@ -180,8 +180,8 @@ class WordPressFreeScoutServiceProvider extends ServiceProvider
 			$settings = \WordPressFreeScout::getMailboxSettings($mailbox);
 
 			echo \View::make('wordpressfreescout::partials/orders', [
-				'results'        => $results['data'],
-				'error'          => $results['error'],
+				'results'        => $results['data'] ?? false,
+				'error'          => $results['error'] ?? '',
 				'customer_email' => $emails[0],
 				'load'           => false,
 				'url'            => \WordPressFreeScout::getSanitizedUrl( $settings['url'] ),


### PR DESCRIPTION
Resolves this error:

```
[2023-11-10 13:54:59] production.ERROR: Undefined array key "data" (View: /var/www/html/resources/views/conversations/view.blade.php) {"userId":1,"email":"admin@gravitykit.com","exception":"[object] (ErrorException(code: 0): Undefined array key \"data\" (View: /var/www/html/resources/views/conversations/view.blade.php) at /var/www/html/Modules/WordPressFreeScout/Providers/WordPressFreeScoutServiceProvider.php:183, ErrorException(code: 0): Undefined array key \"data\" at /var/www/html/Modules/WordPressFreeScout/Providers/WordPressFreeScoutServiceProvider.php:183)
```